### PR TITLE
0.1.1

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,7 +10,7 @@ import { builtinModules } from 'module';
 import { dependencies } from './package.json';
 
 const usePreferConst = true; // Use "const" instead of "var"
-const usePreserveModules = false; // Combine everything is a single file
+const usePreserveModules = true; // `true` -> keep modules structure, `false` -> combine everything into a single file
 const useStrict = true; // Use "strict"
 const useThrowOnError = true; // On error throw and exception
 const useSourceMap = true; // Generate source map files


### PR DESCRIPTION
Set the preserveModules output option of rollup to 'true' to preserve modules structure.
This is recommendend for threeshaking